### PR TITLE
記事一覧のレイアウト変更。レスポンシブは未実装。（#23）

### DIFF
--- a/src/client/components/Articles/ArticleBigArea.jsx
+++ b/src/client/components/Articles/ArticleBigArea.jsx
@@ -11,9 +11,15 @@ const useStyles = makeStyles((theme) => ({
     padding: theme.spacing(2),
     backgroundColor: "black",
     border: "solid 1px #7597c1",
+    marginTop: "8px"
   },
   media: {
-    height: 422,
+    [theme.breakpoints.up("sm")]: {
+      height: 350,
+    },
+    [theme.breakpoints.down("sm")]: {
+      height: 175,
+    },
     backgroundColor: "#fff",
     overflow: "hidden",
     position: "relative",
@@ -35,7 +41,12 @@ const useStyles = makeStyles((theme) => ({
     opacity: ".6",
     width: "100%",
     height: "20%",
-    fontSize: "25px",
+    [theme.breakpoints.up("sm")]: {
+      fontSize: "25px",
+    },
+    [theme.breakpoints.down("sm")]: {
+      fontSize: "15px",
+    },
     fontWeight: 200,
     transition: ".3s",
     cursor: "pointer"

--- a/src/client/components/Articles/ArticleMiddleArea.jsx
+++ b/src/client/components/Articles/ArticleMiddleArea.jsx
@@ -10,8 +10,8 @@ import Typography from "@material-ui/core/Typography";
 
 const useStyles = makeStyles((theme) => ({
   paper: {
-    width: "250px",
-    margin: "5% 1.4%",
+    width: "298px",
+    margin: "5% 1.5% -2% 1%",
     padding: theme.spacing(2),
     textAlign: "center",
     backgroundColor: "black",

--- a/src/client/components/Articles/ArticleSmallArea.jsx
+++ b/src/client/components/Articles/ArticleSmallArea.jsx
@@ -7,13 +7,14 @@ import ListItemText from "@material-ui/core/ListItemText";
 
 const useStyles = makeStyles({
   list: {
-    width: "65%",
+    width: "85%",
     border: "solid 1px #7597c1",
     backgroundColor: "black",
     color: "white",
-    margin: "1% auto",
-    borderRadius: "5px",
+    margin: "0 0 2.5% auto",
+    borderRadius: "4px",
     cursor: "pointer",
+    paddingLeft: 0,
     "&:hover": {
       backgroundColor: "#2f2f2f",
     }

--- a/src/client/components/Articles/ArticlesArea.jsx
+++ b/src/client/components/Articles/ArticlesArea.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { makeStyles } from "@material-ui/core/styles";
-import Container from "@material-ui/core/Container";
 import { ArticleBigArea, ArticleMiddleArea, ArticleSmallArea } from "./index";
 import CircularProgress from "@material-ui/core/CircularProgress";
 import Grid from "@material-ui/core/Grid";
@@ -16,8 +15,21 @@ const useStyles = makeStyles((theme) => ({
       width: "17%"
     },
     [theme.breakpoints.up("md")]: {
-      width: "7%"
+      width: "12%"
     }
+  },
+  parent: {
+    [theme.breakpoints.up("sm")]: {
+      display: "flex"
+    }
+  },
+  bigMiddleDiv: {
+    [theme.breakpoints.up("sm")]: {
+      width: "75%"
+    },
+    [theme.breakpoints.down("sm")]: {
+      width: "100%"
+    },
   }
 }));
 
@@ -25,7 +37,7 @@ const ArticlesArea = (props) => {
   const classes = useStyles();
   const articles = props.articles;
 
-  const articleMiddle = props.articles.slice(1, 4); // 中項目の記事要素
+  const articleMiddle = props.articles.slice(1, 5); // 中項目の記事要素
   const articleBig = props.articles.shift(); // 大項目の記事要素
   
   console.log(articleBig);
@@ -33,45 +45,51 @@ const ArticlesArea = (props) => {
   console.log("articleBig");
 
   return (
-    <Container maxWidth="md">
-      <div>
-        <h2 className={classes.types}>国内</h2>
-        {/* 大項目領域 */}
-        {articleBig !== void 0 && (
-          <ArticleBigArea
-            urlToImage={articleBig.urlToImage} author={articleBig.author} title={articleBig.title}
-            description={articleBig.description} url={articleBig.url}
-            content={articleBig.content} publishedAt={articleBig.publishedAt}
-          />
-        )}
-        {articleBig === void 0 && (<CircularProgress disableShrink />)}
+    <>
+      <h2 className={classes.types}>国内</h2>
+      <div className={classes.parent}>
+        <div className={classes.bigMiddleDiv}>
+          <div>
+            {/* 大項目領域 */}
+            {articleBig !== void 0 && (
+              <ArticleBigArea
+                urlToImage={articleBig.urlToImage} author={articleBig.author} title={articleBig.title}
+                description={articleBig.description} url={articleBig.url}
+                content={articleBig.content} publishedAt={articleBig.publishedAt}
+              />
+            )}
+            {articleBig === void 0 && (<CircularProgress disableShrink />)}
+          </div>
+          {/* 中項目領域 */}
+          <div>
+            <Grid container spacing={3}>
+              {articleMiddle.map((article, i) => (
+                <ArticleMiddleArea
+                  key={i} urlToImage={articleBig.urlToImage} author={articleBig.author}
+                  title={articleBig.title} description={articleBig.description} url={articleBig.url}
+                  content={articleBig.content} publishedAt={articleBig.publishedAt}
+                />
+              ))}
+            </Grid>
+            {articleMiddle === void 0 && (<CircularProgress disableShrink />)}
+          </div>
+        </div>
+        <div>
+          {/* 小項目領域 */}
+          <div>
+            <List>
+              {articles.map((article, i) => (
+                <ArticleSmallArea
+                  key={i} urlToImage={article.urlToImage} author={article.author}
+                  title={article.title} description={article.description} url={article.url}
+                  content={article.content} publishedAt={article.publishedAt}
+                />
+              ))}
+            </List>
+          </div>
+        </div>
       </div>
-      {/* 中項目領域 */}
-      <div>
-        <Grid container spacing={3}>
-          {articleMiddle.map((article, i) => (
-            <ArticleMiddleArea
-              key={i} urlToImage={articleBig.urlToImage} author={articleBig.author}
-              title={articleBig.title} description={articleBig.description} url={articleBig.url}
-              content={articleBig.content} publishedAt={articleBig.publishedAt}
-            />
-          ))}
-        </Grid>
-        {articleMiddle === void 0 && (<CircularProgress disableShrink />)}
-      </div>
-      {/* 小項目領域 */}
-      <div>
-        <List>
-          {articles.map((article, i) => (
-            <ArticleSmallArea
-              key={i} urlToImage={article.urlToImage} author={article.author}
-              title={article.title} description={article.description} url={article.url}
-              content={article.content} publishedAt={article.publishedAt}
-            />
-          ))}
-        </List>
-      </div>
-    </Container>
+    </>
   )
 }
 

--- a/src/client/components/Header/Header.jsx
+++ b/src/client/components/Header/Header.jsx
@@ -10,9 +10,8 @@ const useStyles = makeStyles({
     flexGrow: 1,
   },
   menuBar: {
-    backgroundColr: "#fff",
     color: "white",
-    backgroundColor: "black",
+    backgroundColor: "#1b1b1b",
     border: "solid 1px #7597c1",
     borderRadius: "6px"
   },

--- a/src/client/templates/Articles.jsx
+++ b/src/client/templates/Articles.jsx
@@ -3,11 +3,16 @@ import Container from "@material-ui/core/Container";
 import { Topics, ArticlesArea } from "../components/Articles";
 import { makeStyles } from "@material-ui/core/styles";
 
-const useStyles = makeStyles({
+const useStyles = makeStyles((theme) => ({
   root: {
-    marginTop: "9%"
+    [theme.breakpoints.up("sm")]: {
+      marginTop: "9%"
+    },
+    [theme.breakpoints.down("sm")]: {
+      marginTop: "30%"
+    }
   }
-});
+}));
 
 const Articles = () => {
 


### PR DESCRIPTION
- レスポンスシブ対応は別チケット
- 大項目と中項目の右側に小項目を置き、スクロールせず情報量を増やした

[![Image from Gyazo](https://i.gyazo.com/6d24ac841d745b07041166173d7a2eb4.jpg)](https://gyazo.com/6d24ac841d745b07041166173d7a2eb4)